### PR TITLE
plantuml: make server build time configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,10 +41,11 @@ RUN set -x && \
 
 # Set plantuml.com as plantuml renderer. Alternative would be to deploy plantuml
 # "Fix" executable war (which seems to confuse jar & zip utilities)
+ARG PLANTUMLSERVER="http://www.plantuml.com/plantuml/png/"
 RUN set -x && \
   zip -F /tmp/smeagol-exec.war --out /tmp/smeagol.war && \
   unzip /tmp/smeagol.war -d ${CATALINA_HOME}/smeagol && \
-  sed -i "s/rendererURL\:\"\/plantuml\/png\//rendererURL\:\"http:\/\/www.plantuml.com\/plantuml\/png\//g" "$(ls ${CATALINA_HOME}/smeagol/WEB-INF/classes/static/static/js/main*.js)"
+  sed -i "s#rendererURL:\"/plantuml/png/#rendererURL:\"${PLANTUMLSERVER}#g" "$(ls ${CATALINA_HOME}/smeagol/WEB-INF/classes/static/static/js/main*.js)"
 
 # Aggregate /dist to copied into one layer of the final image
 # CAS config


### PR DESCRIPTION
Now you can configure the PlantUML server at build time via

    [...] --build-arg PLANTUMLSERVER="https://[...]/png/" [...]

Important: you need the last slash '/'!

Signed-off-by: Silvio Fricke <silvio.fricke@gmail.com>